### PR TITLE
Explicit verision for librarian-puppet ruby gem

### DIFF
--- a/shell/prereqs.sh
+++ b/shell/prereqs.sh
@@ -42,7 +42,7 @@ fi
 cp /vagrant/$1/Puppetfile $PUPPET_DIR
 
 if [ "$(gem search -i librarian-puppet)" = "false" ]; then
-  gem install librarian-puppet
+  gem install librarian-puppet -v 1.0.0
   cd $PUPPET_DIR && librarian-puppet install --clean
 else
   cd $PUPPET_DIR && librarian-puppet update


### PR DESCRIPTION
Initialization was failing due to incompatible dependencies for librarian-puppet
